### PR TITLE
Opcode fix

### DIFF
--- a/leroy.s
+++ b/leroy.s
@@ -39,7 +39,7 @@ aggro_eggs:
 	fork %:howling_terror
 	ld %0, r15
 	ld %1, r14
-	fork %: more_dots
+	fork %:more_dots
 	st r1, 11
 	st r2, 21
 	fork %:flee

--- a/src/asm/label_utils2.c
+++ b/src/asm/label_utils2.c
@@ -6,7 +6,7 @@
 /*   By: csphilli <csphilli@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/15 13:58:00 by csphilli          #+#    #+#             */
-/*   Updated: 2021/02/26 08:00:33 by csphilli         ###   ########.fr       */
+/*   Updated: 2021/03/15 11:07:14 by csphilli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ char	*ft_charcat(char *dest, const char src)
 	size_t		dest_l;
 
 	i = 0;
-	dest_l = strlen(dest);
+	dest_l = ft_strlen(dest);
 	dest[dest_l + i] = src;
 	dest[dest_l + i + 1] = '\0';
 	return ((char *)dest);

--- a/src/asm/token_utils.c
+++ b/src/asm/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: csphilli <csphilli@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 20:39:12 by csphilli          #+#    #+#             */
-/*   Updated: 2021/03/15 10:51:27 by csphilli         ###   ########.fr       */
+/*   Updated: 2021/03/15 10:56:23 by csphilli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 */
 
 void			opcode_error(t_master *m, char *opname)
-{	
+{
 	if (ft_strlen(opname) == 0)
 		ft_putstr_fd("ERROR: Missing opcode on line ", 2);
 	else

--- a/src/asm/token_utils.c
+++ b/src/asm/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: csphilli <csphilli@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 20:39:12 by csphilli          #+#    #+#             */
-/*   Updated: 2021/03/15 10:56:23 by csphilli         ###   ########.fr       */
+/*   Updated: 2021/03/15 11:17:29 by csphilli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 void			opcode_error(t_master *m, char *opname)
 {
 	if (ft_strlen(opname) == 0)
-		ft_putstr_fd("ERROR: Missing opcode on line ", 2);
+		ft_putstr_fd("ERROR: Missing opcode instruction on line ", 2);
 	else
 	{
 		ft_putstr_fd("ERROR: Invalid opcode \'", 2);
@@ -46,7 +46,7 @@ t_asm_oplist	get_opcode(t_master *m, char *line)
 	len = 0;
 	while (ft_strchr(OPNAME_CHAR, line[len]))
 		len++;
-	str = strndup(line, sizeof(char) * len);
+	str = ft_strndup(line, sizeof(char) * len);
 	while (i < OP_COUNT)
 	{
 		if (ft_strequ(str, g_oplist[i].opname))

--- a/src/asm/token_utils.c
+++ b/src/asm/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: csphilli <csphilli@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 20:39:12 by csphilli          #+#    #+#             */
-/*   Updated: 2021/02/26 08:00:33 by csphilli         ###   ########.fr       */
+/*   Updated: 2021/03/15 10:51:27 by csphilli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,10 +17,15 @@
 */
 
 void			opcode_error(t_master *m, char *opname)
-{
-	ft_putstr_fd("ERROR: Invalid opcode \'", 2);
-	ft_putstr_fd(opname, 2);
-	ft_putstr_fd("\' found on line ", 2);
+{	
+	if (ft_strlen(opname) == 0)
+		ft_putstr_fd("ERROR: Missing opcode on line ", 2);
+	else
+	{
+		ft_putstr_fd("ERROR: Invalid opcode \'", 2);
+		ft_putstr_fd(opname, 2);
+		ft_putstr_fd("\' on line ", 2);
+	}
 	ft_putnbr_fd(m->line_cnt, 2);
 	ft_putstr_fd(".\n", 2);
 	exit(1);

--- a/src/asm/tokenizing.c
+++ b/src/asm/tokenizing.c
@@ -6,7 +6,7 @@
 /*   By: csphilli <csphilli@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 16:55:10 by csphilli          #+#    #+#             */
-/*   Updated: 2021/02/26 08:00:33 by csphilli         ###   ########.fr       */
+/*   Updated: 2021/03/15 09:43:59 by csphilli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,6 +89,7 @@ void	tokenizing_cont(t_master *m, t_ins *ins, \
 **	type_parse is in the type_parse.c file.
 **	add_labels is above.
 **	tokenizing_cont is above.
+**	get_opcode is in token_utils.c
 */
 
 void	tokenizing(t_master *m, char *line)


### PR DESCRIPTION
updated the opcode_error message to account for instances where the string that would include the error opname name is empty. That would happen in situations where you have an acceptable label name and acceptable label_chars afterwards such as:
label:lkjsdflkj234lkj234